### PR TITLE
File markup error

### DIFF
--- a/examples/jira.gitbugtraq
+++ b/examples/jira.gitbugtraq
@@ -2,5 +2,5 @@
 # It could instead be added as an additional section to $GIT_DIR/config.
 # (note that '\' need to be escaped).
 [bugtraq]
-  https://jira.atlassian.com/browse/%BUGID%
+  url = https://jira.atlassian.com/browse/%BUGID%
   logregex = (JRA-\\d+)


### PR DESCRIPTION
This file cannot be parsed properly by SmartGit for example, because it misses "url = " before the URL. I've fixed this.