### PR TITLE
Add "github" configuration example.

### DIFF
--- a/examples/github.gitbugtraq
+++ b/examples/github.gitbugtraq
@@ -1,0 +1,7 @@
+# An example content of .gitbugtraq to put in the repository root directory.
+# It could instead be added as an additional section to $GIT_DIR/config.
+# (note that '\' need to be escaped).
+[bugtraq]
+  url = https://github.com/username/project/issues/%BUGID%
+  loglinkregex = "#\\d+"
+  logregex = \\d+


### PR DESCRIPTION
It was quite easy to find the right configuration, based on the Mantis one, but I find it odd that Github was missing.