### PR TITLE
Fallback to UTF-8 if commit encoding is unsupported

### DIFF
--- a/implementations/java/src/com/syntevo/bugtraq/BugtraqConfig.java
+++ b/implementations/java/src/com/syntevo/bugtraq/BugtraqConfig.java
@@ -30,6 +30,9 @@
 package com.syntevo.bugtraq;
 
 import java.io.*;
+import java.nio.charset.Charset;
+import java.nio.charset.IllegalCharsetNameException;
+import java.nio.charset.UnsupportedCharsetException;
 import java.util.*;
 
 import org.eclipse.jgit.errors.*;
@@ -39,6 +42,8 @@ import org.eclipse.jgit.storage.file.*;
 import org.eclipse.jgit.treewalk.*;
 import org.eclipse.jgit.treewalk.filter.*;
 import org.jetbrains.annotations.*;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 public final class BugtraqConfig {
 
@@ -214,7 +219,7 @@ public final class BugtraqConfig {
 					FileMode entmode = tw.getFileMode(0);
 					if (FileMode.REGULAR_FILE == entmode) {
 						ObjectLoader ldr = repository.open(entid, Constants.OBJ_BLOB);
-						content = new String(ldr.getCachedBytes(), commit.getEncoding());
+						content = new String(ldr.getCachedBytes(), guessEncoding(commit));
 						break;
 					}
 				}
@@ -248,6 +253,15 @@ public final class BugtraqConfig {
 			}
 		}
 		return baseConfig;
+	}
+
+	@NotNull
+	private static Charset guessEncoding(RevCommit commit) {
+		try {
+			return commit.getEncoding();
+		} catch (IllegalCharsetNameException | UnsupportedCharsetException e) {
+			return UTF_8;
+		}
 	}
 
 	@Nullable


### PR DESCRIPTION
Reading the encoding of a commit can result in a Unsupported- or IllegalCharsetException. This happens when for whatever reason the commit has an encoding recorded that the system doesn't understand. This could also be erroneous entires like `utf-9` or `'utf8'`. Instead of completely failing, fallback to UTF-8.