### PR TITLE
.gitbugtraq: #24 Update the GitHub integration not to use the filter

### DIFF
--- a/.gitbugtraq
+++ b/.gitbugtraq
@@ -1,5 +1,4 @@
 [bugtraq]
   url = https://github.com/mstrap/bugtraq/issues/%BUGID%
-  logfilterregex = "(?i)(?:(?:Issues?) ?[#]?(?:[ ,:;#]*\\d+)*)"
-  loglinkregex = "#?\\d+"
+  loglinkregex = "#\\d+"
   logregex = \\d+


### PR DESCRIPTION
I updated the config to be inline with my other sample repositories!

e.g #24 is sufficent to have the issue links working!