### PR TITLE
github.gitbugtraq: #26 update the GitHub integration example 

### DIFF
--- a/examples/github-with-filterregex.gitbugtraq
+++ b/examples/github-with-filterregex.gitbugtraq
@@ -3,7 +3,7 @@
 # (note that '\' need to be escaped).
 [bugtraq]
   url = https://github.com/username/project/issues/%BUGID%
-  #detects all issues in commit messages like "#5"
-  loglinkregex = "#\\d+"
+  #detects all issues in commit messages like "Issue #5:" 
+  logfilterregex = "(?i)(?:(?:Issues?) ?[#]?(?:[ ,:;#]*\\d+)*)"
+  loglinkregex = "#?\\d+"
   logregex = \\d+
-


### PR DESCRIPTION
Added the more complex regex to match "Issue #<issueid>:" that was orginally used in this repo to the GitHub Example .gitbugtraq file